### PR TITLE
UnitAura states, auraInstanceID update

### DIFF
--- a/BlizzardCode.lua
+++ b/BlizzardCode.lua
@@ -42,6 +42,7 @@ function KHMRaidFrames:CompactUnitFrame_UtilSetDebuff(debuffFrame, unit, index, 
         debuffFrame.count:Hide()
     end
     debuffFrame:SetID(index)
+    debuffFrame.auraInstanceID = aura.auraInstanceID;
     local enabled = aura.expirationTime and aura.expirationTime ~= 0
     if enabled then
         local startTime = aura.expirationTime - aura.duration

--- a/KHMRaidFrames.lua
+++ b/KHMRaidFrames.lua
@@ -204,9 +204,10 @@ function KHMRaidFrames:CompactUnitFrame_UpdateHealthColorInternal(frame, groupTy
     end
 
     local cache = self.coloredFrames[name]
+    local fR, fG, fB, fA = frame.healthBar:GetStatusBarColor()
 
     if not self.useClassColors then
-        if frame.healthBar.r ~= cache.health.r or frame.healthBar.g ~= cache.health.g or frame.healthBar.b ~= cache.health.b then
+        if fR ~= cache.health.r or fG ~= cache.health.g or fB ~= cache.health.b then
             if frame.unit and not UnitIsConnected(frame.unit) then
                 r, g, b = 0.5, 0.5, 0.5
             elseif CompactUnitFrame_IsTapDenied(frame) then
@@ -215,15 +216,14 @@ function KHMRaidFrames:CompactUnitFrame_UpdateHealthColorInternal(frame, groupTy
                 r, g, b = db.color[1], db.color[2], db.color[3]
             end
 
-            frame.healthBar:SetStatusBarColor(r, g, b)
-
-            self.coloredFrames[name].health = {
-                r=frame.healthBar.r,
-                g=frame.healthBar.g,
-                b=frame.healthBar.b,
+           frame.healthBar:SetStatusBarColor(r, g, b)              
+           self.coloredFrames[name].health = {
+                r=r,
+                g=g,
+                b=b,
             }
         end
-    end
+    end 
 end
 --
 

--- a/KHMRaidFrames.toc
+++ b/KHMRaidFrames.toc
@@ -1,7 +1,7 @@
-## Interface: 100002
+## Interface: 100007
 ## Title: KHM Raid Frames
 ## Notes: Extended Standart Raid\Party Frames
-## Version: 1.3.4
+## Version: 1.3.5
 ## Author: kvirtx
 ## SavedVariables: KHMRaidFramesDB
 ## SavedVariablesPerCharacter: KHMRaidFrames_SyncProfiles


### PR DESCRIPTION
- Fix custom size buffs
- New api UnitAura (usePackedAura)
- Update buffs / debuffs with auraInstanceID state (10.0 update)

> Auras now have an "instance ID" (auraInstanceID) which uniquely refers to an instance of an aura for the duration of its lifetime on a unit. The instance ID is expected to remain stable and suitable for use as a table key between successive updates of auras on a unit until a full aura update occurs. 

The old version causes errors because the tooltip now requires an auraInstanceID ( C_TooltipInfo.GetUnitBuffByAuraInstanceID )

- Fix cache frame colors

![wKA84rI](https://user-images.githubusercontent.com/19764573/235808901-91714c6d-04ac-4264-b2ab-a00f45b247d4.png)

Some frames after joined a group could be displayed as "disconnected"

frame.healthBar always {0,1,0}
You can get current color with frame:GetStatusBarColor()






